### PR TITLE
Remove bower and gulp as global requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# texenergo #
+# texenergo
 
 ## Dependencies
-* Node.js (https://nodejs.org/)
+* [Node.js](https://nodejs.org/) (better install and manage with [nvm](https://github.com/creationix/nvm#installation))
 * NPM (usually installed with Node.js)
-* Bower (`sudo npm install -g bower`)
-* gulp (`sudo npm install -g gulp`)
 
 ## Install
-```
+```bash
 $ npm install
-$ bower install
 ```
 
 ## Build
-`$ gulp`
+```bash
+$ npm run build
+```
 
 ## Launch
-`$ gulp server`
+```bash
+$ npm run server
+```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.html",
-  "scripts": {},
+  "scripts": {
+    "postinstall": "bower install",
+    "build": "gulp",
+    "server": "gulp server"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/marzhaev/texenergo_app"
@@ -17,6 +21,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-preset-es2015": "^6.18.0",
+    "bower": "^1.8.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
В это PR'e я перенёс bower и gulp из глобальных зависимостей в локальные.

Что это значит:
- теперь разработчику нет надобности иметь установленные глобально gulp и bower (как мне например - я ни тем ни другим уже не пользуюсь) для запуска проекта
- если глобально установлена версия `g1` gulp'a и версия `b1` bower'a, на которых разработчик собирает свой пет проджект или коммерческое приложение работодателя, а для этого проекта нужны `g1` и `b2` соответственно - придётся каждый раз приседать с актуализацией версий для всех проектов, в которых он принимает участие. Соответственно, если эти сборщики/пакетные менеджеры установлены локально - то и проблемы нет. Все пользуются только нужными версиями в рамках разных проектов и определёнными версиями в рамках конкретного проекта. 
- глобал не засорён всевозможными gulp'ами, bower`ами, grunt'ами и webpack'ами (а их уже 3 версии! и далеко не везде пользуются последней)
- дока короче, требований меньше
- локальные версии gulp/bower запускаются через `package.json` скрипты - единственная точка входа для манипулаций с проектом.